### PR TITLE
Properly escape query params

### DIFF
--- a/lib/frodata/query.rb
+++ b/lib/frodata/query.rb
@@ -132,20 +132,20 @@ module FrOData
     # Convert Query to string.
     # @return [String]
     def to_s
-      [entity_set.name, assemble_criteria].compact.join('?')
+      criteria = params.map { |k, v| "#{k}=#{v}" }.join('&')
+      [entity_set.name, params.any? ? criteria : nil].compact.join('?')
     end
 
     # Execute the query.
     # @return [FrOData::Service::Response]
-    def execute(url_chunk = self.to_s)
-      service.execute(url_chunk, options.merge(query: self))
+    def execute(url_chunk = entity_set.name, params = assemble_criteria)
+      service.execute(url_chunk, options.merge(query: self, params: params))
     end
 
     # Executes the query to get a count of entities.
     # @return [Integer]
     def count
-      url_chunk = ["#{entity_set.name}/$count", assemble_criteria].compact.join('?')
-      response = self.execute(url_chunk)
+      response = self.execute("#{entity_set.name}/$count")
       # Some servers (*cough* Microsoft *cough*) seem to
       # return extraneous characters in the response.
       response.body.scan(/\d+/).first.to_i
@@ -162,6 +162,10 @@ module FrOData
     # @api private
     def entity_set
       @entity_set
+    end
+
+    def params
+      assemble_criteria || {}
     end
 
     # The service for this query
@@ -191,7 +195,7 @@ module FrOData
     end
 
     def assemble_criteria
-      criteria = [
+      [
         filter_criteria,
         search_criteria,
         list_criteria(:orderby),
@@ -200,34 +204,33 @@ module FrOData
         inline_count_criteria,
         paging_criteria(:skip),
         paging_criteria(:top)
-      ].compact!
-
-      criteria.empty? ? nil : criteria.join('&')
+      ].compact.reduce(&:merge)
     end
 
     def filter_criteria
       return nil if criteria_set[:filter].empty?
       filters = criteria_set[:filter].collect(&:to_s)
-      "$filter=#{filters.join(' and ')}"
+      { '$filter' => filters.join(' and ') }
     end
 
     def search_criteria
       return nil if criteria_set[:search].empty?
       filters = criteria_set[:search].collect(&:to_s)
-      "$search=#{filters.join(' AND ')}"
+      { '$search' => filters.join(' AND ') }
     end
 
     def list_criteria(name)
-      criteria_set[name].empty? ? nil : "$#{name}=#{criteria_set[name].join(',')}"
+      return nil if criteria_set[name].empty?
+      { "$#{name}" => criteria_set[name].join(',') }
     end
 
     # inlinecount not supported by Microsoft CRM 2011
     def inline_count_criteria
-      criteria_set[:inline_count] ? '$count=true' : nil
+      criteria_set[:inline_count] ? { '$count' => 'true' } : nil
     end
 
     def paging_criteria(name)
-      criteria_set[name] == 0 ? nil : "$#{name}=#{criteria_set[name]}"
+      criteria_set[name] == 0 ? nil : { "$#{name}" => criteria_set[name] }
     end
   end
 end

--- a/lib/frodata/query.rb
+++ b/lib/frodata/query.rb
@@ -164,6 +164,8 @@ module FrOData
       @entity_set
     end
 
+    # The parameter hash for this query.
+    # @return [Hash] Params hash
     def params
       assemble_criteria || {}
     end
@@ -177,9 +179,7 @@ module FrOData
 
     private
 
-    def criteria_set
-      @criteria_set
-    end
+    attr_reader :criteria_set
 
     def setup_empty_criteria_set
       @criteria_set = {

--- a/lib/frodata/service/request.rb
+++ b/lib/frodata/service/request.rb
@@ -27,7 +27,7 @@ module FrOData
       # Return the full request URL (including service base)
       # @return [String]
       def url
-        ::URI.join("#{service.service_url}/", ::URI.escape(url_chunk)).to_s
+        connection.build_url(url_chunk).to_s
       end
 
       # The content type for this request. Depends on format.
@@ -47,16 +47,18 @@ module FrOData
       # @param request_options [Hash] Request options to pass to Faraday
       # @return [FrOData::Service::Response]
       def execute(request_options = {})
-        Response.new(service, query) do
-          connection.run_request(method, url_chunk, nil, headers) do |conn|
-            conn.options.merge! request_options
-          end
-        end
+        Response.new(service, query) { make_request(request_options) }
       end
 
       private
 
       attr_reader :url_chunk
+
+      def make_request(request_options = {})
+        connection.run_request(method, url_chunk, nil, headers) do |req|
+          req.options.merge! request_options
+        end
+      end
 
       def default_headers
         {

--- a/lib/frodata/service/request.rb
+++ b/lib/frodata/service/request.rb
@@ -10,6 +10,8 @@ module FrOData
       attr_accessor :method
       # The request format (`:atom`, `:json`, or `:auto`)
       attr_accessor :format
+      # Params hash
+      attr_accessor :params
 
       # Create a new request
       # @param service [FrOData::Service] Where the request will be sent
@@ -21,13 +23,14 @@ module FrOData
         @method = options.delete(:method) || :get
         @format = options.delete(:format) || :auto
         @query  = options.delete(:query)
+        @params = options.delete(:params)
         @options = options
       end
 
       # Return the full request URL (including service base)
       # @return [String]
       def url
-        connection.build_url(url_chunk).to_s
+        connection.build_url(url_chunk, params).to_s
       end
 
       # The content type for this request. Depends on format.
@@ -56,6 +59,7 @@ module FrOData
 
       def make_request(request_options = {})
         connection.run_request(method, url_chunk, nil, headers) do |req|
+          req.params.update(params) if params
           req.options.merge! request_options
         end
       end

--- a/spec/fixtures/vcr_cassettes/entity_set_specs.yml
+++ b/spec/fixtures/vcr_cassettes/entity_set_specs.yml
@@ -1632,4 +1632,163 @@ http_interactions:
         Punch","Description":"Mango flavor, 8.3 Ounce Cans (Pack of 24)","ReleaseDate":"2003-01-05T00:00:00Z","DiscontinuedDate":null,"Rating":3,"Price":22.99}]}'
     http_version: 
   recorded_at: Tue, 24 Apr 2018 01:58:50 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/V4/OData/OData.svc/Products(1)?%24expand=Categories&%7B%22%24expand%22=%3E%22Categories%22%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.0
+      OData-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '339'
+      content-type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      vary:
+      - Accept-Encoding
+      server:
+      - Microsoft-IIS/10.0
+      x-content-type-options:
+      - nosniff
+      odata-version:
+      - 4.0;
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET
+      access-control-allow-headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      access-control-expose-headers:
+      - DataServiceVersion
+      date:
+      - Mon, 04 Jun 2018 19:07:17 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context":"http://services.odata.org/V4/OData/OData.svc/$metadata#Products/$entity","ID":1,"Name":"Milk","Description":"Low
+        fat milk","ReleaseDate":"1995-10-01T00:00:00Z","DiscontinuedDate":null,"Rating":3,"Price":3.5,"Categories":[{"ID":0,"Name":"Food"},{"ID":1,"Name":"Beverages"}]}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 19:07:17 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/V4/OData/OData.svc/Products(1)?%24expand=Categories%2CSupplier%2CProductDetail&%7B%22%24expand%22=%3E%22Categories%2CSupplier%2CProductDetail%22%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.0
+      OData-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '589'
+      content-type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      vary:
+      - Accept-Encoding
+      server:
+      - Microsoft-IIS/10.0
+      x-content-type-options:
+      - nosniff
+      odata-version:
+      - 4.0;
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET
+      access-control-allow-headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      access-control-expose-headers:
+      - DataServiceVersion
+      date:
+      - Mon, 04 Jun 2018 19:07:17 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context":"http://services.odata.org/V4/OData/OData.svc/$metadata#Products/$entity","ID":1,"Name":"Milk","Description":"Low
+        fat milk","ReleaseDate":"1995-10-01T00:00:00Z","DiscontinuedDate":null,"Rating":3,"Price":3.5,"Categories":[{"ID":0,"Name":"Food"},{"ID":1,"Name":"Beverages"}],"Supplier":{"ID":0,"Name":"Exotic
+        Liquids","Address":{"Street":"NE 228th","City":"Sammamish","State":"WA","ZipCode":"98074","Country":"USA"},"Location":{"type":"Point","coordinates":[-122.03547668457,47.6316604614258],"crs":{"type":"name","properties":{"name":"EPSG:4326"}}},"Concurrency":0},"ProductDetail":{"ProductID":1,"Details":"Details
+        of product 1"}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 19:07:17 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/V4/OData/OData.svc/Products(1)?%24expand=Categories%2CSupplier&%7B%22%24expand%22=%3E%22Categories%2CSupplier%22%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.0
+      OData-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '559'
+      content-type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      vary:
+      - Accept-Encoding
+      server:
+      - Microsoft-IIS/10.0
+      x-content-type-options:
+      - nosniff
+      odata-version:
+      - 4.0;
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET
+      access-control-allow-headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      access-control-expose-headers:
+      - DataServiceVersion
+      date:
+      - Mon, 04 Jun 2018 19:07:17 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context":"http://services.odata.org/V4/OData/OData.svc/$metadata#Products/$entity","ID":1,"Name":"Milk","Description":"Low
+        fat milk","ReleaseDate":"1995-10-01T00:00:00Z","DiscontinuedDate":null,"Rating":3,"Price":3.5,"Categories":[{"ID":0,"Name":"Food"},{"ID":1,"Name":"Beverages"}],"Supplier":{"ID":0,"Name":"Exotic
+        Liquids","Address":{"Street":"NE 228th","City":"Sammamish","State":"WA","ZipCode":"98074","Country":"USA"},"Location":{"type":"Point","coordinates":[-122.03547668457,47.6316604614258],"crs":{"type":"name","properties":{"name":"EPSG:4326"}}},"Concurrency":0}}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 19:07:18 GMT
 recorded_with: VCR 4.0.0

--- a/spec/fixtures/vcr_cassettes/query_specs.yml
+++ b/spec/fixtures/vcr_cassettes/query_specs.yml
@@ -1057,4 +1057,261 @@ http_interactions:
       string: '0'
     http_version: 
   recorded_at: Tue, 24 Apr 2018 01:58:54 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/V4/OData/OData.svc/Products/$count?%24filter=Name+eq+%27Bread%27&%7B%22%24filter%22=%3E%22Name+eq+%27Bread%27%22%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.0
+      OData-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '120'
+      content-type:
+      - text/plain;charset=utf-8
+      vary:
+      - Accept-Encoding
+      server:
+      - Microsoft-IIS/10.0
+      x-content-type-options:
+      - nosniff
+      odata-version:
+      - 4.0;
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET
+      access-control-allow-headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      access-control-expose-headers:
+      - DataServiceVersion
+      date:
+      - Mon, 04 Jun 2018 18:44:51 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '1'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 18:44:51 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/V4/OData/OData.svc/Products(0)?%24expand=Categories&%7B%22%24expand%22=%3E%22Categories%22%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.0
+      OData-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '326'
+      content-type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      vary:
+      - Accept-Encoding
+      server:
+      - Microsoft-IIS/10.0
+      x-content-type-options:
+      - nosniff
+      odata-version:
+      - 4.0;
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET
+      access-control-allow-headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      access-control-expose-headers:
+      - DataServiceVersion
+      date:
+      - Mon, 04 Jun 2018 18:44:51 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context":"http://services.odata.org/V4/OData/OData.svc/$metadata#Products/$entity","ID":0,"Name":"Bread","Description":"Whole
+        grain bread","ReleaseDate":"1992-01-01T00:00:00Z","DiscontinuedDate":null,"Rating":4,"Price":2.5,"Categories":[{"ID":0,"Name":"Food"}]}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 18:44:52 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/V4/OData/OData.svc/Products/$count?%24filter=Name+eq+%27NonExistent%27&%7B%22%24filter%22=%3E%22Name+eq+%27NonExistent%27%22%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.0
+      OData-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '120'
+      content-type:
+      - text/plain;charset=utf-8
+      vary:
+      - Accept-Encoding
+      server:
+      - Microsoft-IIS/10.0
+      x-content-type-options:
+      - nosniff
+      odata-version:
+      - 4.0;
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET
+      access-control-allow-headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      access-control-expose-headers:
+      - DataServiceVersion
+      date:
+      - Mon, 04 Jun 2018 18:44:51 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '0'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 18:44:52 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/V4/OData/OData.svc/Products/$count?%7B%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.0
+      OData-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '121'
+      content-type:
+      - text/plain;charset=utf-8
+      vary:
+      - Accept-Encoding
+      server:
+      - Microsoft-IIS/10.0
+      x-content-type-options:
+      - nosniff
+      odata-version:
+      - 4.0;
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET
+      access-control-allow-headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      access-control-expose-headers:
+      - DataServiceVersion
+      date:
+      - Mon, 04 Jun 2018 18:47:10 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '11'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 18:47:10 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/V4/OData/OData.svc/Products(0)?%7B%7D
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Faraday v0.15.0
+      OData-Version:
+      - '4.0'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      cache-control:
+      - no-cache
+      content-length:
+      - '302'
+      content-type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      vary:
+      - Accept-Encoding
+      server:
+      - Microsoft-IIS/10.0
+      x-content-type-options:
+      - nosniff
+      odata-version:
+      - 4.0;
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+      access-control-allow-origin:
+      - "*"
+      access-control-allow-methods:
+      - GET
+      access-control-allow-headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      access-control-expose-headers:
+      - DataServiceVersion
+      date:
+      - Mon, 04 Jun 2018 18:47:10 GMT
+      connection:
+      - close
+    body:
+      encoding: ASCII-8BIT
+      string: '{"@odata.context":"http://services.odata.org/V4/OData/OData.svc/$metadata#Products/$entity","ID":0,"Name":"Bread","Description":"Whole
+        grain bread","ReleaseDate":"1992-01-01T00:00:00Z","DiscontinuedDate":null,"Rating":4,"Price":2.5}'
+    http_version: 
+  recorded_at: Mon, 04 Jun 2018 18:47:11 GMT
 recorded_with: VCR 4.0.0

--- a/spec/frodata/query_spec.rb
+++ b/spec/frodata/query_spec.rb
@@ -15,18 +15,21 @@ describe FrOData::Query, vcr: {cassette_name: 'query_specs'} do
     type: 'ODataDemo.Product'
   } }
 
-  it { expect(subject).to respond_to(:to_s) }
-  it { expect(subject.to_s).to eq('Products')}
-
-  it { expect(subject).to respond_to(:[]) }
-  describe '#[]' do
-    it { expect(subject[:Name]).to be_a(FrOData::Query::Criteria) }
-    it {  expect(subject[:Name].property).to be_a(FrOData::Property) }
+  describe '#to_s' do
+    it { expect(subject).to respond_to(:to_s) }
+    it { expect(subject.to_s).to eq('Products')}
   end
 
-  it { expect(subject).to respond_to(:find) }
+  describe '#[]' do
+    it { expect(subject).to respond_to(:[]) }
+    it { expect(subject[:Name]).to be_a(FrOData::Query::Criteria) }
+    it { expect(subject[:Name].property).to be_a(FrOData::Property) }
+  end
+
   describe '#find' do
     let(:product) { subject.find(0) }
+
+    it { expect(subject).to respond_to(:find) }
 
     it 'finds an entity by its ID' do
       expect(product).to be_a(FrOData::Entity)
@@ -41,26 +44,32 @@ describe FrOData::Query, vcr: {cassette_name: 'query_specs'} do
     end
   end
 
-  it { expect(subject).to respond_to(:where) }
   describe '#where' do
     let(:criteria) { subject[:Name].eq('Bread') }
+    let(:params) {{ '$filter' => "Name eq 'Bread'" }}
     let(:query_string) { "Products?$filter=Name eq 'Bread'" }
 
+    it { expect(subject).to respond_to(:where) }
     it { expect(subject.where(criteria)).to eq(subject) }
+    it { expect(subject.where(criteria).params).to eq(params) }
     it { expect(subject.where(criteria).to_s).to eq(query_string) }
   end
 
-  it { expect(subject).to respond_to(:search) }
   describe '#search' do
     let(:term) { '"mountain bike"' }
+    let(:params) {{ '$search' => '"mountain bike"' }}
     let(:query_string) { 'Products?$search="mountain bike"' }
 
+    it { expect(subject).to respond_to(:search) }
     it { expect(subject.search(term)).to eq(subject) }
+    it { expect(subject.search(term).params).to eq(params) }
     it { expect(subject.search(term).to_s).to eq(query_string) }
 
     describe 'with multiple terms' do
+      let(:params) {{ '$search' => '"mountain bike" AND NOT clothing' }}
       let(:query_string) { 'Products?$search="mountain bike" AND NOT clothing' }
 
+      it { expect(subject.search(term).search('NOT clothing').params).to eq(params) }
       it { expect(subject.search(term).search('NOT clothing').to_s).to eq(query_string) }
     end
   end
@@ -75,57 +84,62 @@ describe FrOData::Query, vcr: {cassette_name: 'query_specs'} do
     it { pending; fail }
   end
 
-  it { expect(subject).to respond_to(:skip) }
   describe '#skip' do
+    it { expect(subject).to respond_to(:skip) }
     it { expect(subject.skip(5)).to eq(subject) }
     it 'properly formats query with skip specified' do
       subject.skip(5)
+      expect(subject.params).to eq('$skip' => 5)
       expect(subject.to_s).to eq('Products?$skip=5')
     end
   end
 
-  it { expect(subject).to respond_to(:limit) }
   describe '#limit' do
-
+    it { expect(subject).to respond_to(:limit) }
     it { expect(subject.limit(5)).to eq(subject) }
     it 'properly formats query with limit specified' do
       subject.limit(5)
+      expect(subject.params).to eq('$top' => 5)
       expect(subject.to_s).to eq('Products?$top=5')
     end
   end
 
-  it { expect(subject).to respond_to(:include_count) }
   describe '#include_count' do
+    it { expect(subject).to respond_to(:include_count) }
     it { expect(subject.include_count).to eq(subject) }
     it 'properly formats query with include_count specified' do
       subject.include_count
+      expect(subject.params).to eq('$count' => 'true')
       expect(subject.to_s).to eq('Products?$count=true')
     end
   end
 
-  it { expect(subject).to respond_to(:select) }
   describe '#select' do
+    it { expect(subject).to respond_to(:select) }
     it { expect(subject.select(:Name, :Price)).to eq(subject) }
     it 'properly formats query with select operation specified' do
       subject.select(:Name, :Price)
+      expect(subject.params).to eq('$select' => 'Name,Price')
       expect(subject.to_s).to eq('Products?$select=Name,Price')
     end
   end
 
-  it { expect(subject).to respond_to(:expand) }
   describe '#expand' do
+    it { expect(subject).to respond_to(:expand) }
     it { expect(subject.expand(:Supplier)).to eq(subject) }
     it 'properly formats query with expand operation specified' do
       subject.expand(:Supplier)
+      expect(subject.params).to eq('$expand' => 'Supplier')
       expect(subject.to_s).to eq('Products?$expand=Supplier')
     end
   end
 
-  it { expect(subject).to respond_to(:order_by) }
   describe '#order_by' do
+    it { expect(subject).to respond_to(:order_by) }
     it { expect(subject.order_by(:Name, :Price)).to eq(subject) }
     it 'properly formats query with orderby operation specified' do
       subject.order_by(:Name, :Price)
+      expect(subject.params).to eq('$orderby' => 'Name,Price')
       expect(subject.to_s).to eq('Products?$orderby=Name,Price')
     end
   end

--- a/spec/frodata/service/request_spec.rb
+++ b/spec/frodata/service/request_spec.rb
@@ -10,6 +10,12 @@ describe FrOData::Service::Request, vcr: {cassette_name: 'service/request_specs'
     it 'returns the full request URL' do
       expect(subject.url).to eq('http://services.odata.org/V4/OData/OData.svc/Products')
     end
+
+    it 'properly escapes control characters' do
+      params = { '$filter' => "contains(Name,'Proctor & Gamble')" }
+      subject = described_class.new(service, 'Suppliers', params: params)
+      expect(subject.url).to match(/Name%2C%27Proctor\+%26\+Gamble%27/)
+    end
   end
 
   describe '#method' do


### PR DESCRIPTION
# Summary

When creating a query with a string containing a `&` symbol, the resulting URL query string was not properly escaped. 

This was due to the way that `FrOData::Query` was executing queries – it would assemble the entire URL fragment (pathname + query params) as a string, instead of passing query parameters as a Hash and letting the HTTP library assemble the query string. This PR fixes that.

This resolves #1. 